### PR TITLE
modified admin server dockerfile to support running multiple admin servers using the same GCSBucket

### DIFF
--- a/saxml/tools/docker/Dockerfile.admin
+++ b/saxml/tools/docker/Dockerfile.admin
@@ -42,14 +42,17 @@ ENV SAX_CELL=/sax/test
 # Use "10000" as default port for admin server gRPC endpoint.
 ENV PORT=10000
 
-ENV SAX_ROOT=gs://${GSBUCKET}/sax-root
-ENV FS_ROOT=gs://${GSBUCKET}/sax-fs-root
-
+ENV SAX_ROOT=""
+ENV FS_ROOT=""
 # Create a script that configures and runs the admin server.
 RUN echo '#!/bin/bash\n\
+if [[ -z "$SAX_ROOT"  ]]; then\n\
+        SAX_ROOT=gs://${GSBUCKET}/sax-root \n\ 
+        FS_ROOT=gs://${GSBUCKET}/sax-fs-root \n\
+fi\n\
 admin_config \
   --sax_cell=${SAX_CELL} \
-  --sax_root=${SAX_ROOT} \
+  --sax_root=${SAX_ROOT}\
   --fs_root=${FS_ROOT} \
   --alsologtostderr\n\
 admin_server \
@@ -57,6 +60,7 @@ admin_server \
   --sax_root=${SAX_ROOT} \
   --port=${PORT} \
   --alsologtostderr\n' \
+  --v=3 \
 > /usr/bin/admin_server_entrypoint.sh && chmod +x /usr/bin/admin_server_entrypoint.sh
 
 ENTRYPOINT ["/usr/bin/admin_server_entrypoint.sh"]

--- a/saxml/tools/docker/Dockerfile.admin
+++ b/saxml/tools/docker/Dockerfile.admin
@@ -42,16 +42,19 @@ ENV SAX_CELL=/sax/test
 # Use "10000" as default port for admin server gRPC endpoint.
 ENV PORT=10000
 
+ENV SAX_ROOT=gs://${GSBUCKET}/sax-root
+ENV FS_ROOT=gs://${GSBUCKET}/sax-fs-root
+
 # Create a script that configures and runs the admin server.
 RUN echo '#!/bin/bash\n\
 admin_config \
   --sax_cell=${SAX_CELL} \
-  --sax_root=gs://${GSBUCKET}/sax-root \
-  --fs_root=gs://${GSBUCKET}/sax-fs-root \
+  --sax_root=${SAX_ROOT} \
+  --fs_root=${FS_ROOT} \
   --alsologtostderr\n\
 admin_server \
   --sax_cell=${SAX_CELL} \
-  --sax_root=gs://${GSBUCKET}/sax-root \
+  --sax_root=${SAX_ROOT} \
   --port=${PORT} \
   --alsologtostderr\n' \
 > /usr/bin/admin_server_entrypoint.sh && chmod +x /usr/bin/admin_server_entrypoint.sh

--- a/saxml/tools/docker/Dockerfile.admin
+++ b/saxml/tools/docker/Dockerfile.admin
@@ -60,7 +60,6 @@ admin_server \
   --sax_root=${SAX_ROOT} \
   --port=${PORT} \
   --alsologtostderr\n' \
-  --v=3 \
 > /usr/bin/admin_server_entrypoint.sh && chmod +x /usr/bin/admin_server_entrypoint.sh
 
 ENTRYPOINT ["/usr/bin/admin_server_entrypoint.sh"]


### PR DESCRIPTION
Setting SAX_ROOT and FS_ROOT as an environment variable allows an easy way to modify where the admin server data is stored. The current changes submitted break the default configuration of the SaxML servers. However, this is a necessary change in order to be able to run multiple admin servers using the same GCSBucket. So would like to use this PR as a discussion for possible changes to keep the default configuration running as well as be able to support this new feature. 

